### PR TITLE
add type for provider configuration

### DIFF
--- a/src/avatarConnect.ts
+++ b/src/avatarConnect.ts
@@ -9,6 +9,7 @@ import {
   BridgeResult,
   BridgeEvent,
   SdkOptions,
+  Provider,
 } from './types'
 
 const MAJOR_VERSION = '__WEBPACK_VERSION_STUB__'
@@ -20,7 +21,7 @@ class AvatarConnect extends EventEmitter {
   private readonly bridge: Bridge
 
   constructor(
-    providers = [],
+    providers: Provider[] = [],
     {
       bridgeUrl = DEFAULT_BRIDGE_URL,
       maxWidth = 800,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ interface ConfiguredProviderTuple extends Array<string | object> {
   1: object
 }
 
-type Provider = string | ConfiguredProviderTuple
+export type Provider = string | ConfiguredProviderTuple
 
 export interface BridgeConfiguration {
   providers: Provider[]


### PR DESCRIPTION
If the SDK is used in a typescript project, you run into issues with defining the provider configuration (e.g., type string is not assignable to type never). I checked the SDK implementation and added types for the providers. They were already defined but not used.